### PR TITLE
Update required version of WP-CLI

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "files": [ "command.php" ]
     },
     "require": {
-        "wp-cli/wp-cli": "^1.1.0"
+        "wp-cli/wp-cli": ">=1.1.0"
     },
     "require-dev": {
         "behat/behat": "~2.5"


### PR DESCRIPTION
Updates the composer requirements to allow WP_CLI v2+.
