### PR TITLE
Pass $before arg through strtotime.

### DIFF
--- a/command.php
+++ b/command.php
@@ -28,7 +28,12 @@ class WP_Prune_Command extends WP_CLI_Command {
 	function posts( $args, $assoc_args ) {
 		global $wpdb;
 
-		$before = $assoc_args['before'] ?? date( 'Y-m-d H:i:s', strtotime( '-6 months' ) );
+		if ( ! empty( $assoc_args['before'] ) ) {
+			$before = strtotime( $assoc_args['before'] );
+		} else {
+			$before = date( 'Y-m-d H:i:s', strtotime( '-6 months' ) );
+		}
+		
 		$sample_rate = floatval( $assoc_args['sample_rate'] ?? '.8' );
 
 		$post_types = explode( ',', $assoc_args['post_type'] ?? '' );


### PR DESCRIPTION
I've been caught out by the way the `before` argument works. It actually requires a date e.g. `2020-01-01`, yet it defaults to '6 months ago', and this is noted in the command help . My issue is that I assumed I would need to pass a similar string. But `--before="1 year ago"` doesn't work. A recent project even documented it as such. It took me looking at the code to work out why it didn't work. 

One possible solution is to just pass this through `strtotime`. This would still work OK for anyone passing a mysql formatted date too -`strtotime( `2020-01-01` )` works fine. 

If you have any concerns about doing this, the other solution is to just update the documentation to make the format clear.  e.g. 

> Cutoff date to prune posts before. Requires date in MySQL date format YY-MM-DD. Defaults to 6 months ago.

Further to this, for the benefit of writing better evergreen documentation, it would be great if there was a way to calculate 1 year ago inline. Pseudocode: `wp posts prune --before+$( date -1 year formatted as YY-MM-DD )`
